### PR TITLE
feat(login): add simplistic login page, controller and guard

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -22,6 +22,8 @@ security:
             guard:
                 authenticators:
                     - App\Security\TokenAuthenticator
+                    - App\Security\LoginFormAuthenticator
+                entry_point: App\Security\TokenAuthenticator
 
     access_control:
         - { path: '^/api', roles: ROLE_USER }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,5 +3,8 @@ app_logout:
     methods: GET
 login:
     path:       /login
-    controller: App\Controller\SecurityController::login
-    methods: POST
+    controller: App\Controller\LoginController::showForm
+
+protected_route:
+    path: /protected
+    controller: App\Controller\ProtectedPartController::protectedZone

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class LoginController
+{
+    public function showForm(): Response
+    {
+        $formMarkup = <<<END
+<form action="/login" method="POST">
+    <div>
+        <label for="username">username</label>
+        <input type="text" name="username" id="username">
+    </div>
+    
+    <div>
+        <label for="password">password</label>
+        <input type="password" name="password" id="password">
+    </div>
+    
+    <div>
+        <button type="submit">login</button>
+    </div>
+</form>
+END;
+
+
+        return new Response($formMarkup);
+    }
+}

--- a/src/Controller/ProtectedPartController.php
+++ b/src/Controller/ProtectedPartController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\Security;
+
+class ProtectedPartController extends AbstractController
+{
+    private $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    public function protectedZone(): JsonResponse
+    {
+        $this->denyAccessUnlessGranted('ROLE_USER');
+
+        return new JsonResponse([
+            'message' => 'if you can see this, then your token is correct',
+            'username' => $this->security->getUser()->getUsername(), // there always will be a user, since we guard with denyAccessUnlessGranted
+        ]);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -36,6 +36,7 @@ class User implements UserInterface
 
   /**
    * @ORM\Column(type="string", unique=true, nullable=true)
+   * @var string
    */
   private $apiToken;
 
@@ -111,5 +112,15 @@ class User implements UserInterface
   {
       // If you store any temporary, sensitive data on the user, clear it here
       // $this->plainPassword = null;
+  }
+
+  public function getApiToken(): string
+  {
+      return $this->apiToken;
+  }
+
+  public function setApiToken(string $apiToken): void
+  {
+      $this->apiToken = $apiToken;
   }
 }

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Security;
+
+use App\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class LoginFormAuthenticator extends AbstractGuardAuthenticator
+{
+    private $passwordEncoder;
+    private $userRepository;
+
+    public function __construct(UserPasswordEncoderInterface $encoder, UserRepository $userRepository)
+    {
+        $this->passwordEncoder = $encoder;
+        $this->userRepository = $userRepository;
+    }
+
+    public function supports(Request $request)
+    {
+        return $request->isMethod('POST') && $request->attributes->get('_route') === 'login';
+    }
+
+    public function getCredentials(Request $request)
+    {
+        return [
+            'username' => $request->get('username'),
+            'password' => $request->get('password'),
+        ];
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        return $this->userRepository->findOneBy(['username' => $credentials['username']]);
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        return $this->passwordEncoder->isPasswordValid($user, $credentials['password']);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        // no need to do anything else
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $providerKey)
+    {
+        return new JsonResponse(['token' => $token->getUser()->getApiToken()]);
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        // no need, since this guard is used only for login page
+    }
+
+    public function supportsRememberMe()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Not the best code in the world, but it should give you the idea and direction.

* `/login` route. There you can do anything you want, the main idea is to provide route to hook LoginFormAuthenticator into + display at least some UI (I'm not familiar with vue.js, so it's the best I can do quickly and without additional css or templates)
* `LoginController` is just there to show the form
* `ProtectedController` is just there to check that `x-auth-token` works
* `User` - I've added 2 methods for apiToken, but actually use only getter (for after authentication)
* `LoginFormAuthenticator` - very basic stuff, you probably will want to tinker it more. see [docs](https://symfony.com/doc/current/security/guard_authentication.html#the-guard-authenticator-methods) for explanation of flow and methods.
    * Basically we use it only on post requests to `/login` route (better to use name of the route instead of literal path btw) (see `supports` method),
    * extract username and password from query (`getCredentials`)
    * search for user via repository with provided username (`getUser`)
    * check credentials (provided password = password from DB) (`checkCredentials`)
    * if everything is ok - respond with json with current token from DB.
    * that's all
* `security.yaml` - maybe it's better to add 1 more firewall and move `LoginFormAuthenticator` there, so `main` can remain simple


